### PR TITLE
Fix dealer card reveal persistence when starting new game

### DIFF
--- a/Common/UI/BlackjackOverlayUI.cs
+++ b/Common/UI/BlackjackOverlayUI.cs
@@ -238,8 +238,8 @@ namespace Blackjack.Common.UI
             // Returns true if a game is currently in progress
             public bool GetActiveGame() => isGameActive;
 
-            // True while a card animation is occurring
-            public bool IsAnimating => currentDealingCard != null || dealingQueue.Count > 0;
+            // True while a card animation or dealer flip animation is occurring
+            public bool IsAnimating => currentDealingCard != null || dealingQueue.Count > 0 || flippingDealerCard;
 
             public override void OnInitialize()
             {
@@ -282,6 +282,8 @@ namespace Blackjack.Common.UI
                 dealingQueue.Clear();
                 currentDealingCard = null;
                 dealerTurn = false;
+                flippingDealerCard = false;
+                dealerCardFlipProgress = 0f;
 
                 // Deal one card to player and one to dealer and repeat
                 playerCards.Clear();


### PR DESCRIPTION
## Summary
- stop the dealer flip animation from continuing into the next game
- treat dealer card flips as an animation so Play can't be pressed until finished

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68479d1b2ed08328a650f3de34ea342e