### PR TITLE
Fix UI persisting across world loads

### DIFF
--- a/Common/UI/BlackjackOverlayUISystem.cs
+++ b/Common/UI/BlackjackOverlayUISystem.cs
@@ -36,6 +36,16 @@ namespace Blackjack.Common.UI
             blackjackUI.Activate();
         }
 
+        public override void OnWorldUnload()
+        {
+            HideUI();
+        }
+
+        public override void OnWorldLoad()
+        {
+            HideUI();
+        }
+
         public override void UpdateUI(GameTime gameTime)
         {
             // Here we call .Update on our custom UI and propagate it to its state and underlying elements


### PR DESCRIPTION
## Summary
- hide the blackjack overlay when the world loads or unloads

## Testing
- `dotnet build Blackjack.csproj -nologo` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a302d92a48328905422d7ada0deed