### PR TITLE
Fix close button layering on UI startup

### DIFF
--- a/Common/UI/BlackjackOverlayUI.cs
+++ b/Common/UI/BlackjackOverlayUI.cs
@@ -59,7 +59,6 @@ namespace Blackjack.Common.UI
             closeButton = new UIHoverImageButton(buttonCloseTexture, Language.GetTextValue("LegacyInterface.52")); // Localized text for "Close"
             SetRectangle(closeButton, left: boxWidth - 60f, top: 40f, width: 44f, height: 44f);
             closeButton.OnLeftClick += new MouseEvent(CloseButtonClicked);
-            BlackjackPanel.Append(closeButton);
 
             // Inactive close button
             Asset<Texture2D> buttonCloseInactiveTexture = ModContent.Request<Texture2D>("Blackjack/Assets/ButtonCloseInactive");
@@ -110,6 +109,9 @@ namespace Blackjack.Common.UI
                 // Upon standing, execute dealer logic
                 blackjackGame.DealerLogic();
             };
+
+            // Append the close button last so it appears above other elements
+            BlackjackPanel.Append(closeButton);
 
 
 


### PR DESCRIPTION
## Summary
- fix layering of close button on blackjack panel so it's interactable at startup

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b9d49318083289d44a67046023d19