### PR TITLE
Improve game status visibility

### DIFF
--- a/Common/UI/BlackjackGame.cs
+++ b/Common/UI/BlackjackGame.cs
@@ -96,6 +96,75 @@ namespace Blackjack.Common.UI
         DynamicSpriteFont fontBig = FontAssets.DeathText.Value;
         string gameStatus = "";
 
+        private static Texture2D pixel;
+
+        private static void EnsurePixel()
+        {
+            if (pixel == null)
+            {
+                pixel = new Texture2D(Main.graphics.GraphicsDevice, 1, 1);
+                pixel.SetData(new[] { Color.White });
+            }
+        }
+
+        private static void DrawRoundedRect(SpriteBatch spriteBatch, Rectangle rect, int radius, Color fillColor, Color borderColor, int borderThickness = 2)
+        {
+            EnsurePixel();
+
+            for (int y = 0; y < rect.Height; y++)
+            {
+                int xStart = 0;
+                int xEnd = rect.Width;
+                if (y < radius)
+                {
+                    int x = radius - (int)Math.Sqrt(radius * radius - y * y);
+                    xStart = radius - x;
+                    xEnd = rect.Width - (radius - x);
+                }
+                else if (y >= rect.Height - radius)
+                {
+                    int dy = y - (rect.Height - radius);
+                    int x = radius - (int)Math.Sqrt(radius * radius - dy * dy);
+                    xStart = radius - x;
+                    xEnd = rect.Width - (radius - x);
+                }
+                spriteBatch.Draw(pixel, new Rectangle(rect.X + xStart, rect.Y + y, xEnd - xStart, 1), fillColor);
+            }
+
+            for (int i = 0; i < borderThickness; i++)
+            {
+                Rectangle r = new Rectangle(rect.X + i, rect.Y + i, rect.Width - 2 * i, rect.Height - 2 * i);
+                for (int y = 0; y < r.Height; y++)
+                {
+                    int xStart = 0;
+                    int xEnd = r.Width;
+                    if (y < radius)
+                    {
+                        int x = radius - (int)Math.Sqrt(radius * radius - y * y);
+                        xStart = radius - x;
+                        xEnd = r.Width - (radius - x);
+                    }
+                    else if (y >= r.Height - radius)
+                    {
+                        int dy = y - (r.Height - radius);
+                        int x = radius - (int)Math.Sqrt(radius * radius - dy * dy);
+                        xStart = radius - x;
+                        xEnd = r.Width - (radius - x);
+                    }
+
+                    if (y < borderThickness || y >= r.Height - borderThickness)
+                    {
+                        spriteBatch.Draw(pixel, new Rectangle(r.X + xStart, r.Y + y, xEnd - xStart, 1), borderColor);
+                    }
+                    else
+                    {
+                        spriteBatch.Draw(pixel, new Rectangle(r.X + xStart, r.Y + y, 1, 1), borderColor);
+                        spriteBatch.Draw(pixel, new Rectangle(r.X + xEnd - 1, r.Y + y, 1, 1), borderColor);
+                    }
+                }
+            }
+        }
+
         // Hand value text
         string dealerStatus1 = Language.GetTextValue("Mods.Blackjack.UI.DealerHand");
         string dealerStatus2;
@@ -541,8 +610,12 @@ namespace Blackjack.Common.UI
             Rectangle stackRectangle = new Rectangle((int)(position.X + dims.Width - cardWidth - 20), (int)(position.Y + dims.Height / 2 - stackHeight / 2), cardWidth, stackHeight);
             spriteBatch.Draw(cardStackAsset.Value, stackRectangle, Color.White);
 
-            // Render game status text
-            spriteBatch.DrawString(fontBig, gameStatus, new Vector2(position.X + dims.Width / 2 - fontBig.MeasureString(gameStatus).X / 2, position.Y + dims.Height / 2), Color.White);
+            // Render game status text with background
+            Vector2 statusSize = fontBig.MeasureString(gameStatus);
+            Vector2 statusPos = new Vector2(position.X + dims.Width / 2 - statusSize.X / 2, position.Y + dims.Height / 2);
+            Rectangle bgRect = new Rectangle((int)(statusPos.X - 20), (int)(statusPos.Y - 10), (int)statusSize.X + 40, (int)statusSize.Y + 20);
+            DrawRoundedRect(spriteBatch, bgRect, 8, Color.Black * 0.6f, Color.Black, 2);
+            spriteBatch.DrawString(fontBig, gameStatus, statusPos, Color.White);
 
         }
 


### PR DESCRIPTION
## Summary
- draw rounded rectangle behind game status text
- keep text centered within new background panel

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d0d16069c8328a79110068fef0e66