### PR TITLE
Fix status text overlay

### DIFF
--- a/Common/UI/BlackjackGame.cs
+++ b/Common/UI/BlackjackGame.cs
@@ -582,8 +582,8 @@ namespace Blackjack.Common.UI
 
             // Render game status text centered on the panel
             Vector2 statusSize = fontBig.MeasureString(gameStatus);
-            float panelLeft = position.X + dims.Width / 2f - statusSize.X / 2f - 20f;
-            float panelTop = position.Y + dims.Height / 2f - statusSize.Y / 2f - 10f;
+            float panelLeft = dims.Width / 2f - statusSize.X / 2f - 20f;
+            float panelTop = dims.Height / 2f - statusSize.Y / 2f - 10f;
             statusPanel.Left.Set(panelLeft, 0f);
             statusPanel.Top.Set(panelTop, 0f);
             statusPanel.Width.Set(statusSize.X + 40f, 0f);

--- a/Localization/en-US_Mods.Blackjack.hjson
+++ b/Localization/en-US_Mods.Blackjack.hjson
@@ -24,9 +24,9 @@ Configs: {
 UI: {
 	EmptyBetSlot: Place any form of currency or any metal bar in this slot to bet.
 	DisabledClose: Finish the current game to close the window!
-	Play: Play!
-	Hit: Hit!
-	Stand: Stand!
+	Play: "Play!"
+	Hit: "Hit!"
+	Stand: "Stand!"
 	PlayerWin: You win!
 	PlayerBlackjack: Blackjack! You win!
 	DealerWin: You lose...


### PR DESCRIPTION
## Summary
- ensure `gameStatus` text draws on top of the status panel
- keep the status panel anchored to the game element

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9cc581088328a2d7dcb76e4f6ade