### PR TITLE
Fix localization for UI button hover tooltips

### DIFF
--- a/Common/UI/BlackjackOverlayUI.cs
+++ b/Common/UI/BlackjackOverlayUI.cs
@@ -59,13 +59,13 @@ namespace Blackjack.Common.UI
 
             // Close button
             Asset<Texture2D> buttonCloseTexture = ModContent.Request<Texture2D>("Blackjack/Assets/ButtonClose");
-            closeButton = new UIHoverImageButton(buttonCloseTexture, Language.GetTextValue("LegacyInterface.52")); // Localized text for "Close"
+            closeButton = new UIHoverImageButton(buttonCloseTexture, "LegacyInterface.52"); // Localized text for "Close"
             SetRectangle(closeButton, left: boxWidth - 70f, top: 30f, width: 44f, height: 44f);
             closeButton.OnLeftClick += new MouseEvent(CloseButtonClicked);
 
             // Inactive close button
             Asset<Texture2D> buttonCloseInactiveTexture = ModContent.Request<Texture2D>("Blackjack/Assets/ButtonCloseInactive");
-            closeButtonInactive = new UIHoverImageButton(buttonCloseInactiveTexture, Language.GetTextValue("Mods.Blackjack.UI.DisabledClose"));
+            closeButtonInactive = new UIHoverImageButton(buttonCloseInactiveTexture, "Mods.Blackjack.UI.DisabledClose");
             SetRectangle(closeButtonInactive, left: boxWidth - 70f, top: 30f, width: 44f, height: 44f);
 
             // Blackjack game handler
@@ -82,14 +82,14 @@ namespace Blackjack.Common.UI
 
             // Play button
             Asset<Texture2D> buttonPlayTexture = ModContent.Request<Texture2D>("Blackjack/Assets/ButtonPlay");
-            playButton = new UIHoverImageButton(buttonPlayTexture, Language.GetTextValue("Mods.Blackjack.UI.Play"));
+            playButton = new UIHoverImageButton(buttonPlayTexture, "Mods.Blackjack.UI.Play");
             SetRectangle(playButton, left: boxWidth - 108f, top: boxHeight - 108f, width: 88f, height: 88f);
             playButton.OnLeftClick += new MouseEvent(PlayButtonClicked);
             // BlackjackPanel.Append(playButton); // By default, the play button is hidden until the player places a bet
 
             // Hit button
             Asset<Texture2D> buttonHitTexture = ModContent.Request<Texture2D>("Blackjack/Assets/ButtonHit");
-            hitButton = new UIHoverImageButton(buttonHitTexture, Language.GetTextValue("Mods.Blackjack.UI.Hit"));
+            hitButton = new UIHoverImageButton(buttonHitTexture, "Mods.Blackjack.UI.Hit");
             SetRectangle(hitButton, left: boxWidth / 2 - 96f, top: boxHeight - 108f, width: 88f, height: 88f);
             hitButton.OnLeftClick += (evt, element) =>
             {
@@ -101,7 +101,7 @@ namespace Blackjack.Common.UI
 
             // Stand button
             Asset<Texture2D> buttonStandTexture = ModContent.Request<Texture2D>("Blackjack/Assets/ButtonStand");
-            standButton = new UIHoverImageButton(buttonStandTexture, Language.GetTextValue("Mods.Blackjack.UI.Stand"));
+            standButton = new UIHoverImageButton(buttonStandTexture, "Mods.Blackjack.UI.Stand");
             SetRectangle(standButton, left: boxWidth / 2 + 8f, top: boxHeight - 108f, width: 88f, height: 88f);
             standButton.OnLeftClick += (evt, element) =>
             {

--- a/Common/UI/UIHoverImageButton.cs
+++ b/Common/UI/UIHoverImageButton.cs
@@ -2,27 +2,28 @@
 using ReLogic.Content;
 using Terraria;
 using Terraria.GameContent.UI.Elements;
+using Terraria.Localization;
 
 namespace Blackjack.Common.UI
 {
-	// UI hover image button class from ExampleMod
-	internal class UIHoverImageButton : UIImageButton
-	{
-		// Tooltip text that will be shown on hover
-		internal string hoverText;
+        // UI hover image button class from ExampleMod
+        internal class UIHoverImageButton : UIImageButton
+        {
+                // Key used for localized tooltip text shown on hover
+                internal string hoverTextKey;
 
-		public UIHoverImageButton(Asset<Texture2D> texture, string hoverText) : base(texture) {
-			this.hoverText = hoverText;
-		}
+                public UIHoverImageButton(Asset<Texture2D> texture, string hoverTextKey) : base(texture) {
+                        this.hoverTextKey = hoverTextKey;
+                }
 
-		protected override void DrawSelf(SpriteBatch spriteBatch) {
-			// When you override UIElement methods, don't forget call the base method
-			// This helps to keep the basic behavior of the UIElement
-			base.DrawSelf(spriteBatch);
+                protected override void DrawSelf(SpriteBatch spriteBatch) {
+                        // When you override UIElement methods, don't forget call the base method
+                        // This helps to keep the basic behavior of the UIElement
+                        base.DrawSelf(spriteBatch);
 
-			// IsMouseHovering becomes true when the mouse hovers over the current UIElement
-			if (IsMouseHovering)
-				Main.hoverItemName = hoverText;
-		}
-	}
+                        // IsMouseHovering becomes true when the mouse hovers over the current UIElement
+                        if (IsMouseHovering)
+                                Main.hoverItemName = Language.GetTextValue(hoverTextKey);
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- fix missing localization for overlay button tooltips
- store language keys in `UIHoverImageButton`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dac00d6448328bc444349e77925b7